### PR TITLE
Use libc types instead of manually choosing i32 or i64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,8 @@ mod util;
 mod tests;
 
 use libc::{c_int, c_short, c_void, c_uint, c_ulong, socket, SOCK_RAW, close, bind, sockaddr, read,
-           write, SOL_SOCKET, SO_RCVTIMEO, timespec, timeval, EINPROGRESS, SO_SNDTIMEO};
+           write, SOL_SOCKET, SO_RCVTIMEO, timespec, timeval, EINPROGRESS, SO_SNDTIMEO, time_t,
+           suseconds_t};
 use itertools::Itertools;
 use nix::net::if_::if_nametoindex;
 pub use nl::CanInterface;
@@ -154,20 +155,10 @@ pub const ERR_MASK_ALL: u32 = ERR_MASK;
 /// an error mask that will cause SocketCAN to silently drop all errors
 pub const ERR_MASK_NONE: u32 = 0;
 
-
-#[cfg(target_pointer_width = "64")]
 fn c_timeval_new(t: time::Duration) -> timeval {
     timeval {
-        tv_sec: t.as_secs() as i64,
-        tv_usec: (t.subsec_nanos() / 1000) as i64,
-    }
-}
-
-#[cfg(target_pointer_width = "32")]
-fn c_timeval_new(t: time::Duration) -> timeval {
-    timeval {
-        tv_sec: t.as_secs() as i32,
-        tv_usec: (t.subsec_nanos() / 1000) as i32,
+        tv_sec: t.as_secs() as time_t,
+        tv_usec: (t.subsec_nanos() / 1000) as suseconds_t,
     }
 }
 


### PR DESCRIPTION
Hi Marc,

LIBC's timeval struct is defined as this:

```
timeval {
    tv_sec: time_t;
    tv_usec: suseconds_t
}
```
Those types are available in rust as well, and for that reason should be used.

I had to fix that to use socketcan on x86_64 macos, where `tv_sec` is an i64 while `tv_usec` is an i32. Some differencies may appear on other platforms as well.

Although macos does not support CAN interface, as we use macbooks for development it is very handy to use socketcan for replaying can dumps

Note that this patch works well on top of release 1.6.0; on master branch I get even more errors because of the new dependency to `netlink-rs`. If you accept this change, it would be nice to publish a fixed release 1.6.1!

Best regards