### PR TITLE
Implement embedded_can traits, addresses #15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,11 @@ version = "2.0.0"
 
 [dependencies]
 byte_conv = "0.1.1"
+embedded-can = "0.3"
 hex = "^0.2"
 itertools = "^0.4"
 libc = "^0.2"
+nb = "1.0"
 netlink-rs = { git = "https://github.com/mbr/netlink-rs", rev = "01cba6fcc7b11917890bc3d2b4635009fde8082c" }
 nix = "^0.5"
 try_from = "0.2.0"

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -12,6 +12,7 @@
 //! Can be parsed by a `Reader` object. The API is inspired by the
 //! [csv](https://crates.io/crates/csv) crate.
 
+use crate::{EFF_FLAG, SFF_MASK, Id, ExtendedId, StandardId};
 use std::{fs, io, path};
 use hex::FromHex;
 
@@ -147,16 +148,22 @@ impl<R: io::BufRead> Reader<R> {
         } else {
             Vec::from_hex(&can_data).map_err(|_| ParseError::InvalidCanFrame)?
         };
-        let frame = super::CanFrame::new((parse_raw(can_id, 16)
-                                                  .ok_or
 
+        let can_id_raw= parse_raw(can_id, 16)
+            .ok_or(ParseError::InvalidCanFrame)? as u32;
+    
 
-                                                  (ParseError::InvalidCanFrame))?
-                                              as u32,
-                                              &data,
-                                              rtr,
-                                              // FIXME: how are error frames saved?
-                                              false)?;
+        let can_id = if can_id_raw> SFF_MASK {
+            Id::Extended(ExtendedId::new(can_id_raw | EFF_FLAG).ok_or(ParseError::InvalidCanFrame)?)
+        } else {
+            Id::Standard(StandardId::new(can_id_raw as u16).ok_or(ParseError::InvalidCanFrame)?)
+        };
+    
+        let frame = super::CanFrame::new(can_id,
+                                                &data,
+                                                rtr,
+                                                // FIXME: how are error frames saved?
+                                                false)?;
 
         Ok(Some(CanDumpRecord {
             t_us: t_us,
@@ -195,7 +202,7 @@ mod test {
 
             assert_eq!(rec1.t_us, 1469439874299591);
             assert_eq!(rec1.device, "can1");
-            assert_eq!(rec1.frame.id(), 0x080);
+            assert_eq!(rec1.frame.id_raw(), 0x080);
             assert_eq!(rec1.frame.is_rtr(), false);
             assert_eq!(rec1.frame.is_error(), false);
             assert_eq!(rec1.frame.is_extended(), false);
@@ -206,7 +213,7 @@ mod test {
             let rec2 = reader.next_record().unwrap().unwrap();
             assert_eq!(rec2.t_us, 1469439874299654);
             assert_eq!(rec2.device, "can1");
-            assert_eq!(rec2.frame.id(), 0x701);
+            assert_eq!(rec2.frame.id_raw(), 0x701);
             assert_eq!(rec2.frame.is_rtr(), false);
             assert_eq!(rec2.frame.is_error(), false);
             assert_eq!(rec2.frame.is_extended(), false);


### PR DESCRIPTION
Implement [embedded_can](https://crates.io/crates/embedded-can) crate traits and make use of the Id type defined in the crate. This also fixes the issue #15 making it mandatory to define the type of the ID (extended or standard) rather than just assuming based on the size.